### PR TITLE
Feature/dynamic gnss cov

### DIFF
--- a/config/gnss_filter.param.yaml
+++ b/config/gnss_filter.param.yaml
@@ -1,12 +1,12 @@
 /**:
   ros__parameters:
     gnss_queue_size: 3
+    ekf_queue_size: 500  # 50[Hz] * 10[s]
     default_gnss_pose_covariance: 0.1 # [m^2]
     gnss_pose_covariance_elapsed_scaling_factor: 100.0
     standard_gnss_publish_period: 0.1 # [s]
-    ekf_keep_duration: 1.0
-    outlier_threshold: 2.5
+    outlier_detection_angle_threshold: 0.8
     gnss_too_large_cov_threshold: 1000.0
     ekf_too_large_cov_threshold: 0.025
     enable_duplicate_detection: true
-    enable_outlier_detection: false
+    enable_outlier_detection: true

--- a/config/gnss_filter.param.yaml
+++ b/config/gnss_filter.param.yaml
@@ -6,6 +6,7 @@
     gnss_pose_covariance_elapsed_scaling_factor: 100.0
     standard_gnss_publish_period: 0.1 # [s]
     outlier_detection_angle_threshold: 0.8
+    outlier_detection_distance_threshold: 0.1
     gnss_too_large_cov_threshold: 1000.0
     ekf_too_large_cov_threshold: 0.025
     enable_duplicate_detection: true

--- a/config/gnss_filter.param.yaml
+++ b/config/gnss_filter.param.yaml
@@ -1,8 +1,12 @@
 /**:
   ros__parameters:
     gnss_queue_size: 3
+    default_gnss_pose_covariance: 0.1 # [m^2]
+    gnss_pose_covariance_elapsed_scaling_factor: 100.0
+    standard_gnss_publish_period: 0.1 # [s]
     ekf_keep_duration: 1.0
     outlier_threshold: 2.5
-    too_large_cov_threshold: 0.025
+    gnss_too_large_cov_threshold: 1000.0
+    ekf_too_large_cov_threshold: 0.025
     enable_duplicate_detection: true
-    enable_outlier_detection: true
+    enable_outlier_detection: false

--- a/config/gnss_filter.param.yaml
+++ b/config/gnss_filter.param.yaml
@@ -8,6 +8,6 @@
     outlier_detection_angle_threshold: 0.8
     outlier_detection_distance_threshold: 0.1
     gnss_too_large_cov_threshold: 1000.0
-    ekf_too_large_cov_threshold: 0.025
+    ekf_too_large_cov_threshold: 0.04 # TODO:検討
     enable_duplicate_detection: true
     enable_outlier_detection: true

--- a/config/kart_diag.param.yaml
+++ b/config/kart_diag.param.yaml
@@ -1,16 +1,7 @@
-gnss_filter_for_diag:
-  ros__parameters:
-    gnss_queue_size: 1
-    ekf_keep_duration: 1.0
-    outlier_threshold: 1.0
-    too_large_cov_threshold: 0.04 # TODO:検討
-    enable_duplicate_detection: true
-    enable_outlier_detection: true
-
 kart_diag:
   ros__parameters:
     alert_gnss_duplication_count: 6 # TODO: 検討
     alert_gnss_data_lost_sec: 0.5
-    gnss_filter_node_name: "gnss_filter_for_diag"
+    gnss_filter_node_name: "localization/gnss_filter"
 
 

--- a/launch/gnss_filter_test.launch.xml
+++ b/launch/gnss_filter_test.launch.xml
@@ -2,8 +2,8 @@
 <launch>
   <arg name="vehicle_model" default="racing_kart"  description="vehicle model name"/>
   <arg name="gnss_delay" default="0.5"/>
-  <arg name="use_filtered_gnss" default="false"/>
-  <arg name="use_sim_time"/>
+  <arg name="use_filtered_gnss" default="true"/>
+  <arg name="use_sim_time" default="true"/>
 
   <!-- Global parameters -->
   <group scoped="false">
@@ -18,7 +18,6 @@
 
     <node pkg="aic_tools" exec="gnss_filter" name="gnss_filter" output="both" args="--ros-args --log-level gnss_filter:=debug">
       <param from="$(find-pkg-share aic_tools)/config/gnss_filter.param.yaml"/>
-      <param name="gnss_delay_sec" value="$(var gnss_delay)"/>
       <remap from="/sensing/gnss/pose_with_covariance_filtered" to="/localization_test/sensing/gnss/pose_with_covariance_filtered"/>
     </node>
 
@@ -26,11 +25,13 @@
         <node pkg="imu_gnss_poser" exec="imu_gnss_poser_node" name="imu_gnss_poser" output="screen">
           <remap from="/sensing/gnss/pose_with_covariance" to="/localization_test/sensing/gnss/pose_with_covariance_filtered"/>
           <remap from="/localization/imu_gnss_poser/pose_with_covariance" to="/localization_test/imu_gnss_poser/pose_with_covariance"/>
+          <param name="use_static_covariance" value="false"/>
         </node>
     </group>
     <group unless="$(var use_filtered_gnss)">
         <node pkg="imu_gnss_poser" exec="imu_gnss_poser_node" name="imu_gnss_poser" output="screen">
           <remap from="/localization/imu_gnss_poser/pose_with_covariance" to="/localization_test/imu_gnss_poser/pose_with_covariance"/>
+          <param name="use_static_covariance" value="true"/>
         </node>
     </group>
 

--- a/launch/kart_diag.launch.xml
+++ b/launch/kart_diag.launch.xml
@@ -1,16 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  <arg name="gnss_delay" default="0.3"/>
 
   <group>
-    <node pkg="aic_tools" exec="gnss_filter" name="gnss_filter_for_diag" output="both" args="--ros-args --log-level gnss_filter_for_diag:=fatal">
-      <param from="$(find-pkg-share aic_tools)/config/kart_diag.param.yaml"/>
-      <param name="gnss_delay_sec" value="$(var gnss_delay)"/>
-      <remap from="/sensing/gnss/pose_with_covariance_filtered" to="/sensing/gnss/pose_with_covariance_filtered/muted"/>
-      <remap from="~/distance_from_ekf" to="~/distance_from_ekf/muted"/>
-      <remap from="~/gnss_yaw" to="~/gnss_yaw/muted"/>
-      <remap from="~/gnss_yaw_diff" to="~/gnss_yaw_diff/muted"/>
-    </node>
 
     <node pkg="aic_tools" exec="kart_diag" name="kart_diag" output="both" args="--ros-args --log-level gnss_filter:=info">
       <param from="$(find-pkg-share aic_tools)/config/kart_diag.param.yaml"/>

--- a/src/gnss_filter.cpp
+++ b/src/gnss_filter.cpp
@@ -7,9 +7,13 @@
 
 #include "rclcpp/logging.hpp"
 #include <angles/angles.h>
+#include <builtin_interfaces/msg/detail/time__struct.hpp>
+#include <geometry_msgs/msg/detail/pose_with_covariance_stamped__struct.hpp>
+#include <limits>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <cmath>
 #include <deque>
+#include <ranges>
 
 namespace aic_tools {
 
@@ -26,12 +30,11 @@ public:
     // load parameters
     gnss_queue_size_ =
         static_cast<size_t>(declare_parameter<int64_t>("gnss_queue_size"));
+    ekf_queue_size_ = static_cast<size_t>(declare_parameter<int64_t>("ekf_queue_size"));
     default_gnss_pose_covariance_ = declare_parameter<double>("default_gnss_pose_covariance");
     gnss_pose_covariance_elapsed_scaling_factor_ = declare_parameter<double>("gnss_pose_covariance_elapsed_scaling_factor");
     standard_gnss_publish_period_ = declare_parameter<double>("standard_gnss_publish_period");
-    ekf_keep_duration_ = declare_parameter<double>("ekf_keep_duration");
-    gnss_delay_sec_ = declare_parameter<double>("gnss_delay_sec");
-    outlier_threshold_ = declare_parameter<double>("outlier_threshold");
+    outlier_detection_angle_threshold_ = declare_parameter<double>("outlier_detection_angle_threshold");
     gnss_too_large_cov_threshold_ = declare_parameter<double>("gnss_too_large_cov_threshold");
     ekf_too_large_cov_threshold_ = declare_parameter<double>("ekf_too_large_cov_threshold");
     enable_duplicate_detection_ =
@@ -43,12 +46,8 @@ public:
     pub_gnss_ = this->create_publisher<PoseWithCovarianceStamped>(
         "/sensing/gnss/pose_with_covariance_filtered",
         rclcpp::QoS(rclcpp::KeepLast(10)).reliable());
-    pub_distance_ = this->create_publisher<Float64>(
-        "~/distance_from_ekf", rclcpp::QoS(rclcpp::KeepLast(10)).best_effort());
-    pub_yaw_ = this->create_publisher<Float64>(
-        "~/gnss_yaw", rclcpp::QoS(rclcpp::KeepLast(10)).best_effort());
-    pub_yaw_diff_ = this->create_publisher<Float64>(
-        "~/gnss_yaw_diff", rclcpp::QoS(rclcpp::KeepLast(10)).best_effort());
+    pub_angle_between_gnss_and_ekf_ = this->create_publisher<Float64>(
+        "~/angle_between_gnss_and_ekf", rclcpp::QoS(rclcpp::KeepLast(10)).best_effort());
     pub_duplication_count_ = this->create_publisher<Int64>(
         "~/gnss_duplication_count", rclcpp::QoS(rclcpp::KeepLast(10)).best_effort());
     pub_elapsed_from_last_unique_gnss_received_ = this->create_publisher<Float64>(
@@ -127,10 +126,7 @@ private:
     }
 
     // check outlier
-    const bool is_outlier_detected = is_outlier(*msg);
-    if (is_outlier_detected) {
-      RCLCPP_WARN(get_logger(), "Outlier detected!");
-    }
+    const bool is_outlier_detected = is_outlier(*msg, is_duplicate_detected);
 
     // compute elapsed time from the last unique gnss message
     const auto elapsed_from_last_unique_gnss_received = gnss_queue_.empty() ? 0.0 : compute_stamp_difference(gnss_queue_.back(), *msg);
@@ -157,12 +153,15 @@ private:
       msg->pose.covariance[7*2] = pose_cov;
     }
 
-    // push unique message to the queue
-    if(!is_duplicate_detected) {
+    if(!is_duplicate_detected && !is_outlier_detected && !is_gnss_too_large_cov_detected) {
+        // push unique message to the queue
         if (gnss_queue_.size() >= gnss_queue_size_) {
           gnss_queue_.pop_front();
         }
         gnss_queue_.push_back(*msg);
+
+        // backup the last reliable gnss pose
+        last_reliable_gnss_pose_ = gnss_queue_.back();
     }
 
     // publish the filtered message
@@ -178,6 +177,9 @@ private:
   }
 
   void ekf_odom_callback(const Odometry::SharedPtr msg) {
+    if (ekf_odom_queue_.size() >= ekf_queue_size_) {
+      ekf_odom_queue_.pop_front();
+    }
     ekf_odom_queue_.push_back(*msg);
 
     const bool is_ekf_cov_large_detected = is_too_large_covariance(msg->pose.covariance[0], ekf_too_large_cov_threshold_);
@@ -221,99 +223,90 @@ private:
     return covariance > too_large_cov_threshold;
   }
 
-  bool is_outlier(const PoseWithCovarianceStamped &msg) {
+  bool is_outlier(const PoseWithCovarianceStamped &msg, const bool is_duplicate_detected) {
+    if(!enable_outlier_detection_) {
+      return false;
+    }
+
+    if(is_duplicate_detected) {
+      return false;
+    }
+
     if(ekf_odom_queue_.empty()) {
       return false;
     }
 
-    const double yaw = tier4_autoware_utils::getRPY(msg.pose.pose.orientation).z;
-    const double yaw_diff = angles::shortest_angular_distance(last_yaw_, yaw);
-    const double continuouse_yaw = last_yaw_ + yaw_diff;
-    last_yaw_ = yaw;
-
-    const double ekf_yaw = tier4_autoware_utils::getRPY(ekf_odom_queue_.back().pose.pose.orientation).z;
-    const double ekf_yaw_diff = angles::shortest_angular_distance(last_ekf_yaw_, ekf_yaw);
-    const double continuouse_ekf_yaw = last_ekf_yaw_ + ekf_yaw_diff;
-    last_ekf_yaw_ = ekf_yaw;
-
-    Float64 yaw_msg;
-    yaw_msg.data = yaw;
-    pub_yaw_->publish(yaw_msg);
-
-    // yaw_msg.data = yaw_diff;
-    yaw_msg.data = continuouse_yaw - continuouse_ekf_yaw;
-    pub_yaw_diff_->publish(yaw_msg);
-
-    if (!enable_outlier_detection_) {
+    if(!last_reliable_gnss_pose_.has_value()) {
       return false;
     }
 
-    const auto latest_gnss_time = rclcpp::Time(
-        msg.header.stamp.sec, msg.header.stamp.nanosec, RCL_ROS_TIME);
+    const auto compute_position_diff_unit_vector = [](const geometry_msgs::msg::Pose &p0,
+                                                 const geometry_msgs::msg::Pose &p1) {
+      const double dx = p1.position.x - p0.position.x;
+      const double dy = p1.position.y - p0.position.y;
+      const double norm = std::sqrt(dx * dx + dy * dy);
+      return Eigen::Vector2d(dx / norm, dy / norm);
+    };
 
-    // drop old ekf odom data
-    while (!ekf_odom_queue_.empty() &&
-           (latest_gnss_time - ekf_odom_queue_.front().header.stamp).seconds() >
-               ekf_keep_duration_) {
-      ekf_odom_queue_.pop_front();
-    }
+    const auto get_nearest_stamp_ekf_pose = [&](const builtin_interfaces::msg::Time &time_msg, const bool pop_old) {
 
-    // queueが空の場合は処理しない
-    if (ekf_odom_queue_.empty()) {
-      RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000,
-                           "ekf_odom_queue is empty");
-      return false;
-    }
+      const rclcpp::Time time(time_msg.sec, time_msg.nanosec, RCL_ROS_TIME);
+      double min_diff_time = std::numeric_limits<double>::max();
+      auto nearest_it = ekf_odom_queue_.begin();
 
-    // gnssの取得遅れを考慮して、ekf_odom の少し過去の値を取得
-    const auto target_odom_time =
-        latest_gnss_time - rclcpp::Duration::from_seconds(gnss_delay_sec_);
+      for(auto it = ekf_odom_queue_.begin(); it != ekf_odom_queue_.end(); ++it) {
+        const auto &odom = *it;
+        const double diff_time = std::abs((time - odom.header.stamp).seconds());
 
-    // 最も近い時刻のekf_odomを取得
-    double min_diff_time = std::numeric_limits<double>::max();
-    Odometry ekf_odom;
-    for (const auto &odom : ekf_odom_queue_) {
-      const double diff_time =
-          std::abs((target_odom_time - odom.header.stamp).seconds());
+        if (diff_time > min_diff_time) {
+          break;
+        }
 
-      if (diff_time < min_diff_time) {
         min_diff_time = diff_time;
-        ekf_odom = odom;
+        nearest_it = it;
       }
+
+      const Odometry nearest_ekf_pose = *nearest_it;
+
+      if(pop_old && nearest_it != ekf_odom_queue_.begin()) {
+        ekf_odom_queue_.erase(ekf_odom_queue_.begin(), nearest_it);
+      }
+
+      return nearest_ekf_pose.pose.pose;
+    };
+
+    const auto& last_reliable_gnss_pose = last_reliable_gnss_pose_.value();
+    const auto& latest_gnss_pose = msg;
+
+    const auto last_reliable_gnss_stamped_ekf_pose = get_nearest_stamp_ekf_pose(last_reliable_gnss_pose.header.stamp, true);
+    const auto latest_gnss_stamped_ekf_pose = get_nearest_stamp_ekf_pose(latest_gnss_pose.header.stamp, false);
+
+    const auto gnss_diff_unit_vector = compute_position_diff_unit_vector(last_reliable_gnss_pose.pose.pose, latest_gnss_pose.pose.pose);
+    const auto ekf_diff_unit_vector = compute_position_diff_unit_vector(last_reliable_gnss_stamped_ekf_pose, latest_gnss_stamped_ekf_pose);
+
+    // RCLCPP_WARN(get_logger(), "gnss pose last: (%f, %f), latest: (%f, %f), ekf pose last: (%f, %f), latest: (%f, %f)", last_reliable_gnss_pose.pose.pose.position.x, last_reliable_gnss_pose.pose.pose.position.y, latest_gnss_pose.pose.pose.position.x, latest_gnss_pose.pose.pose.position.y, last_reliable_gnss_stamped_ekf_pose.position.x, last_reliable_gnss_stamped_ekf_pose.position.y, latest_gnss_stamped_ekf_pose.position.x, latest_gnss_stamped_ekf_pose.position.y);
+
+    // RCLCPP_WARN(get_logger(), "gnss vector: (%f, %f), ekf vector: (%f, %f)", gnss_diff_unit_vector.x(), gnss_diff_unit_vector.y(), ekf_diff_unit_vector.x(), ekf_diff_unit_vector.y());
+
+    // compute angle between two vectors
+    const double angle_between_gnss_and_ekf = std::acos(gnss_diff_unit_vector.dot(ekf_diff_unit_vector));
+
+    Float64 angle_msg;
+    angle_msg.data = angle_between_gnss_and_ekf;
+    pub_angle_between_gnss_and_ekf_->publish(angle_msg);
+
+    RCLCPP_DEBUG(get_logger(), "angle: %f", angle_between_gnss_and_ekf);
+
+    if(angle_between_gnss_and_ekf > outlier_detection_angle_threshold_) {
+      RCLCPP_WARN(get_logger(), "Outlier detected! angle_between_gnss_and_ekf: %f", angle_between_gnss_and_ekf);
+      return true;
     }
 
-    // gnssとekf_odomの差分を計算
-    const double distance =
-        std::hypot(msg.pose.pose.position.x - ekf_odom.pose.pose.position.x,
-                   msg.pose.pose.position.y - ekf_odom.pose.pose.position.y);
-
-    // publish distance
-    Float64 distance_msg;
-    distance_msg.data = distance;
-    pub_distance_->publish(distance_msg);
-
-    RCLCPP_DEBUG(get_logger(),
-                 "distance: %f, min_diff_time: %f, queue_remain: %zu", distance,
-                 min_diff_time, ekf_odom_queue_.size());
-
-    // check outlier
-    if (distance < outlier_threshold_) {
-      return false;
-    }
-
-    RCLCPP_WARN(get_logger(),
-                "Outlier detected! expected pose (x: %f, y: %f), "
-                "actual pose (x: %f, y: %f), distance: %f, min_diff_time: %f",
-                ekf_odom.pose.pose.position.x, ekf_odom.pose.pose.position.y,
-                msg.pose.pose.position.x, msg.pose.pose.position.y, distance,
-                min_diff_time);
-
-    return true;
+    return false;
   }
 
   rclcpp::Publisher<PoseWithCovarianceStamped>::SharedPtr pub_gnss_;
-  rclcpp::Publisher<Float64>::SharedPtr pub_distance_;
-  rclcpp::Publisher<Float64>::SharedPtr pub_yaw_, pub_yaw_diff_;
+  rclcpp::Publisher<Float64>::SharedPtr pub_angle_between_gnss_and_ekf_;
   rclcpp::Publisher<Int64>::SharedPtr pub_duplication_count_;
   rclcpp::Publisher<Float64>::SharedPtr pub_elapsed_from_last_unique_gnss_received_;
   rclcpp::Publisher<Bool>::SharedPtr pub_duplication_alert_, pub_outlier_alert_, pub_gnss_large_cov_alert_, pub_ekf_large_cov_alert_;
@@ -326,20 +319,18 @@ private:
 
   // parameters
   size_t gnss_queue_size_;
+  size_t ekf_queue_size_;
   double default_gnss_pose_covariance_;
   double gnss_pose_covariance_elapsed_scaling_factor_;
   double standard_gnss_publish_period_;
-  double ekf_keep_duration_;
-  double outlier_threshold_;
-  double gnss_delay_sec_;
   double gnss_too_large_cov_threshold_;
   double ekf_too_large_cov_threshold_;
+  double outlier_detection_angle_threshold_;
   bool enable_duplicate_detection_;
   bool enable_outlier_detection_;
 
   // runtime states
-  double last_yaw_ = 0.0;
-  double last_ekf_yaw_ = 0.0;
+  std::optional<geometry_msgs::msg::PoseWithCovarianceStamped> last_reliable_gnss_pose_;
   size_t duplication_count_ = 0;
 };
 


### PR DESCRIPTION
# gnss_filter の主な変更点
- duplication, outlier などを検出した時にdropするのではなく、covarianceに反映してpublishするように変更
  - ekf側でgnss の重みをtwistに対して相対的に小さくする効果がある
  - outlier, gnss covariance過大を検出した場合は、過大なcovarianceを、duplicationを検出した時は少しずつcovarianceを大きくするようにした
- 外れ値検出をyawベースから以下のように変更
  - gnss と ekfでそれぞれ速度ベクトル的なもの（位置差分の単位ベクトル）を計算し、そのなす角が大きい時に外れ値とみなす
  - 実機rosbag(trim_12) の外れ値のパターンではうまく機能することを確認した（添付図）
    - `/localization/kinematic_state` がrosbag内に含まれる実際のekf自己位置推定結果
    - `/localization_test/kinematic_state` が ランタイムで gnss_filter とfilter後のgnssをsubするようにしたekfで推定した自己位置推定結果
  - ※ただし、たまたま進行方向に近い方向に外れ値が出た場合はこの手法では検出できない。

![Screenshot from 2024-11-04 23-38-18](https://github.com/user-attachments/assets/076aa4f5-c2fe-4232-924c-be1c7ac53b69)

# 他
- パラメータが増えたり処理が増えた関係で kart_diag 専用の gnss_filter を起動すると冗長なので、そちらのfilterの起動はなしとし、本来のgnss_filter側のメッセージをsubするように変更した