### PR TITLE
kart_diag: 加速度の推定を追加

### DIFF
--- a/config/kart_diag.param.yaml
+++ b/config/kart_diag.param.yaml
@@ -5,5 +5,6 @@ kart_diag:
     steering_rate_alert_threshold: 0.35 # rad/s
     steering_rate_lpf_alpha: 0.1
     gnss_filter_node_name: "localization/gnss_filter"
+    acc_lpf_alpha: 0.3
 
 

--- a/include/aic_tools/kart_diag.hpp
+++ b/include/aic_tools/kart_diag.hpp
@@ -1,13 +1,16 @@
 #pragma once
 
 #include <cstddef>
+#include <std_msgs/msg/detail/float64__struct.hpp>
 #include <unordered_map>
 
 #include <rclcpp/rclcpp.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <std_msgs/msg/bool.hpp>
 #include <std_msgs/msg/empty.hpp>
+#include <std_msgs/msg/float64.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 
 namespace aic_tools {
 
@@ -18,7 +21,9 @@ public:
   using PoseWithCovarianceStamped = geometry_msgs::msg::PoseWithCovarianceStamped;
   using Bool = std_msgs::msg::Bool;
   using Empty = std_msgs::msg::Empty;
+  using Float64 = std_msgs::msg::Float64;
   using SteeringReport = autoware_auto_vehicle_msgs::msg::SteeringReport;
+  using VelReport = autoware_auto_vehicle_msgs::msg::VelocityReport;
 
 public:
   KartDiag();
@@ -30,10 +35,12 @@ bool mpc_controller_alive_{false};
 rclcpp::Subscription<PoseWithCovarianceStamped>::SharedPtr sub_gnss_;
 rclcpp::Subscription<Bool>::SharedPtr sub_gnss_duplication_, sub_gnss_outlier_, sub_gnss_cov_large_, sub_ekf_cov_large_;
 rclcpp::Subscription<SteeringReport>::SharedPtr sub_steering_report_;
+rclcpp::Subscription<VelReport>::SharedPtr sub_vel_status_;
 
 // Publishers
 rclcpp::Publisher<Bool>::SharedPtr pub_gnss_data_lost_alert_;
 rclcpp::Publisher<Bool>::SharedPtr pub_steer_rate_limit_alert_;
+rclcpp::Publisher<Float64>::SharedPtr pub_estimated_acc_;
 
 // Duplication detection
 size_t gnss_duplication_count_;
@@ -52,12 +59,18 @@ double filtered_angle_;
 double last_filtered_angle_;
 rclcpp::Time last_steering_time_{0, 0};
 
+// acc estimation
+double filtered_speed_;
+double last_filtered_speed_;
+rclcpp::Time last_speed_time_{0, 0};
+
 // Parameters
 size_t alert_gnss_duplication_count_;
 double alert_gnss_data_lost_sec_;
 std::string gnss_filter_node_name_;
 double steering_rate_alert_threshold_;
 double steering_rate_lpf_alpha_;
+double acc_lpf_alpha_;
 
 // Timer
 rclcpp::TimerBase::SharedPtr timer_;
@@ -71,6 +84,7 @@ void gnss_outlier_callback(const Bool::SharedPtr msg);
 void gnss_cov_large_callback(const Bool::SharedPtr msg);
 void ekf_cov_large_callback(const Bool::SharedPtr msg);
 void steer_status_callback(const SteeringReport::SharedPtr msg);
+void vel_status_callback(const VelReport::SharedPtr msg);
 void on_shutdown();
 void update_duplicate_count_map();
 void print_stats();


### PR DESCRIPTION
kart_diag に `/vehicle/status/velocity_status` から加速度を推定して pub する機能を追加しました。